### PR TITLE
Add terrain feature layer

### DIFF
--- a/sim/terrain.py
+++ b/sim/terrain.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""Terrain feature layer utilities."""
+
+import numpy as np
+
+# Feature identifiers (uint8)
+# These constants are stable and used for serialization.
+NONE: np.uint8 = np.uint8(0)
+FOREST: np.uint8 = np.uint8(1)
+JUNGLE: np.uint8 = np.uint8(2)
+MARSH: np.uint8 = np.uint8(3)
+SAND: np.uint8 = np.uint8(4)
+HILLS: np.uint8 = np.uint8(5)
+OASIS: np.uint8 = np.uint8(6)
+FOREST_HILLS: np.uint8 = np.uint8(7)
+JUNGLE_HILLS: np.uint8 = np.uint8(8)
+
+# Biome identifiers used for validation.
+BIOME_GRASS = 0
+BIOME_COAST = 1
+BIOME_MOUNTAIN = 2
+BIOME_OCEAN = 3
+BIOME_SAND = 4
+
+# Human readable descriptions for features
+_DESCRIPTIONS = {
+    int(NONE): "None",
+    int(FOREST): "Forest",
+    int(JUNGLE): "Jungle",
+    int(MARSH): "Marsh",
+    int(SAND): "Sand",
+    int(HILLS): "Hills",
+    int(OASIS): "Oasis",
+    int(FOREST_HILLS): "Forest Hills",
+    int(JUNGLE_HILLS): "Jungle Hills",
+}
+
+
+def describe_feature(fid: int) -> str:
+    """Return a human-readable description for ``fid``."""
+    return _DESCRIPTIONS.get(int(fid), "Unknown")
+
+
+def _rand_mask(rng: np.random.Generator, shape: tuple[int, int], prob: float) -> np.ndarray:
+    """Helper to draw a boolean mask with probability ``prob``."""
+    if prob <= 0.0:
+        return np.zeros(shape, dtype=bool)
+    if prob >= 1.0:
+        return np.ones(shape, dtype=bool)
+    return rng.random(shape) < prob
+
+
+def generate_features(biome: np.ndarray, rng: np.random.Generator,
+                      p: dict[str, float]) -> np.ndarray:
+    """Generate terrain features for ``biome``.
+
+    Parameters
+    ----------
+    biome:
+        2D array of biome identifiers (``uint8``).
+    rng:
+        NumPy ``Generator`` used for randomness.
+    p:
+        Mapping from feature name to placement probability. Missing keys default
+        to 0.0.
+
+    Returns
+    -------
+    np.ndarray
+        ``uint8`` array of feature identifiers matching ``biome`` shape.
+    """
+
+    b = np.asarray(biome, dtype=np.uint8)
+    if b.ndim != 2:
+        raise ValueError("biome must be 2D")
+    H, W = b.shape
+    out = np.zeros((H, W), dtype=np.uint8)
+
+    # Masks for biome categories
+    grass = b == BIOME_GRASS
+    sand_bio = b == BIOME_SAND
+    land = (b != BIOME_OCEAN) & (b != BIOME_MOUNTAIN)
+
+    # Exclusive features on grass
+    marsh_mask = grass & _rand_mask(rng, (H, W), p.get("marsh", 0.0))
+    out[marsh_mask] = MARSH
+    available_grass = grass & ~marsh_mask
+
+    forest_mask = available_grass & _rand_mask(rng, (H, W), p.get("forest", 0.0))
+    out[forest_mask] = FOREST
+    available_grass &= ~forest_mask
+
+    jungle_mask = available_grass & _rand_mask(rng, (H, W), p.get("jungle", 0.0))
+    out[jungle_mask] = JUNGLE
+
+    # Exclusive features on sand biome
+    oasis_mask = sand_bio & _rand_mask(rng, (H, W), p.get("oasis", 0.0))
+    out[oasis_mask] = OASIS
+    available_sand = sand_bio & ~oasis_mask
+
+    sand_mask = available_sand & _rand_mask(rng, (H, W), p.get("sand", 0.0))
+    out[sand_mask] = SAND
+
+    # Hills - may stack with forest/jungle
+    hills_mask = land & _rand_mask(rng, (H, W), p.get("hills", 0.0))
+    hills_mask &= (out == NONE) | (out == FOREST) | (out == JUNGLE)
+
+    forest_hills = hills_mask & (out == FOREST)
+    out[forest_hills] = FOREST_HILLS
+
+    jungle_hills = hills_mask & (out == JUNGLE)
+    out[jungle_hills] = JUNGLE_HILLS
+
+    hills_only = hills_mask & (out == NONE)
+    out[hills_only] = HILLS
+
+    # Ensure ocean and mountain tiles have no features
+    out[(b == BIOME_OCEAN) | (b == BIOME_MOUNTAIN)] = NONE
+
+    return out


### PR DESCRIPTION
## Summary
- Define stable uint8 IDs for terrain features and combos
- Implement `generate_features` to apply forests, jungles, marshes, sand, hills, and oasis with stacking rules
- Add `describe_feature` helper for readable feature names

## Testing
- `python -m py_compile sim/terrain.py`
- `python - <<'PY'
import numpy as np
from sim.terrain import generate_features, describe_feature, FOREST, HILLS, FOREST_HILLS

biome = np.array([[0,0,2,3],[0,4,0,0]], dtype=np.uint8)
rng = np.random.default_rng(123)
p = {"forest":1.0, "jungle":0.0, "marsh":0.0, "hills":1.0, "oasis":0.0}
features = generate_features(biome, rng, p)
print("features", features)
print("desc", [describe_feature(int(f)) for f in features.flatten()])
assert features.shape == biome.shape
assert features[0,0] in (FOREST, FOREST_HILLS)
assert features[0,2] == 0  # mountain -> none
assert features[0,3] == 0  # ocean -> none
assert features.dtype == np.uint8
print("OK")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b6f170aa98832cb5c55c54a5c650a8