### PR TITLE
feat(sim): add pure engine + CLI + pygame GUI + autoplay bot + e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+
+# Pytest cache
+.pytest_cache/
+
+# Simulation outputs
+*.json
+!world.json

--- a/bots/autoplay.py
+++ b/bots/autoplay.py
@@ -1,0 +1,10 @@
+from engine import SimulationEngine
+
+def run(world_path: str, weeks: int = 52, save_path: str | None = None) -> dict:
+    eng = SimulationEngine()
+    eng.load_json(world_path)
+    for _ in range(weeks):
+        eng.advance_week()
+    if save_path:
+        eng.save_json(save_path)
+    return eng.summary()

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,77 @@
+import argparse
+from engine import SimulationEngine
+
+def cmd_new(args):
+    eng = SimulationEngine(width=args.width, height=args.height, seed=args.seed)
+    eng.seed_population_everywhere(min_pop=args.min_pop, max_pop=args.max_pop)
+    if args.civ:
+        for spec in args.civ:
+            name, rest = spec.split(":")
+            x, y = map(int, rest.split(","))
+            eng.add_civ(name=name, at=(x, y))
+    eng.save_json(args.out)
+    print(f"World created and saved to {args.out}")
+
+def cmd_step(args):
+    eng = SimulationEngine()
+    eng.load_json(args.world)
+    for _ in range(args.weeks):
+        eng.advance_week()
+    if args.save:
+        eng.save_json(args.save)
+        print(f"Saved to {args.save}")
+    print(eng.summary())
+
+def cmd_summary(args):
+    eng = SimulationEngine()
+    eng.load_json(args.world)
+    print(eng.summary())
+
+def cmd_autoplay(args):
+    eng = SimulationEngine()
+    eng.load_json(args.world)
+    for _ in range(args.weeks):
+        eng.advance_week()
+    if args.save:
+        eng.save_json(args.save)
+        print(f"Saved to {args.save}")
+    print("Auto-play complete.", eng.summary())
+
+def main():
+    ap = argparse.ArgumentParser(description="Headless CLI for simulation")
+    sub = ap.add_subparsers()
+
+    ap_new = sub.add_parser("new", help="Create a new world")
+    ap_new.add_argument("--width", type=int, default=48)
+    ap_new.add_argument("--height", type=int, default=32)
+    ap_new.add_argument("--seed", type=int, default=12345)
+    ap_new.add_argument("--min-pop", type=int, default=3)
+    ap_new.add_argument("--max-pop", type=int, default=30)
+    ap_new.add_argument("--civ", action="append", help="e.g. 'Rome:10,10' (can repeat)")
+    ap_new.add_argument("--out", default="world.json")
+    ap_new.set_defaults(func=cmd_new)
+
+    ap_step = sub.add_parser("step", help="Advance weeks and print summary")
+    ap_step.add_argument("world")
+    ap_step.add_argument("--weeks", type=int, default=1)
+    ap_step.add_argument("--save", default=None)
+    ap_step.set_defaults(func=cmd_step)
+
+    ap_sum = sub.add_parser("summary", help="Print summary")
+    ap_sum.add_argument("world")
+    ap_sum.set_defaults(func=cmd_summary)
+
+    ap_auto = sub.add_parser("autoplay", help="Run a bot for N weeks")
+    ap_auto.add_argument("world")
+    ap_auto.add_argument("--weeks", type=int, default=52)
+    ap_auto.add_argument("--save", default=None)
+    ap_auto.set_defaults(func=cmd_autoplay)
+
+    args = ap.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        ap.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/engine.py
+++ b/engine.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List, Dict, Tuple, Optional
+import json
+import random
+
+Coord = Tuple[int, int]
+
+@dataclass
+class Tile:
+    x: int
+    y: int
+    pop: int = 0
+    owner: Optional[int] = None  # civ_id or None
+
+@dataclass
+class Civ:
+    civ_id: int
+    name: str
+    stock_food: int = 0
+    tiles: List[Coord] = field(default_factory=list)
+
+@dataclass
+class World:
+    width: int
+    height: int
+    tiles: List[Tile]
+    civs: Dict[int, Civ]
+    week: int = 0
+    seed: int = 42
+
+    def idx(self, x: int, y: int) -> int:
+        if x < 0 or y < 0 or x >= self.width or y >= self.height:
+            raise IndexError("tile OOB")
+        return y * self.width + x
+
+    def get_tile(self, x: int, y: int) -> Tile:
+        return self.tiles[self.idx(x, y)]
+
+    def neighbors4(self, x: int, y: int) -> List[Coord]:
+        out: List[Coord] = []
+        for dx, dy in ((1,0),(-1,0),(0,1),(0,-1)):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < self.width and 0 <= ny < self.height:
+                out.append((nx, ny))
+        return out
+
+class SimulationEngine:
+    """Pure-sim API usable by CLI, GUI, and tests."""
+    def __init__(self, width: int = 48, height: int = 32, seed: int = 12345):
+        self.rng = random.Random(seed)
+        self.world = self._new_world(width, height, seed)
+
+    def _new_world(self, w: int, h: int, seed: int) -> World:
+        tiles = [Tile(x=i % w, y=i // w, pop=0, owner=None) for i in range(w*h)]
+        return World(width=w, height=h, tiles=tiles, civs={}, week=0, seed=seed)
+
+    def seed_population_everywhere(self, min_pop=3, max_pop=30) -> None:
+        for t in self.world.tiles:
+            t.pop = self.rng.randint(min_pop, max_pop)
+            t.owner = None
+
+    def add_civ(self, name: str, at: Coord) -> int:
+        if not self._in_bounds(at):
+            raise ValueError("Civ spawn out of bounds")
+        cid = self._next_civ_id()
+        civ = Civ(civ_id=cid, name=name, stock_food=50, tiles=[])
+        self.world.civs[cid] = civ
+        x, y = at
+        t = self.world.get_tile(x, y)
+        if t.owner is not None and t.owner != cid:
+            pass  # allow coexist; must colonize later
+        t.owner = cid
+        civ.tiles.append(at)
+        return cid
+
+    def _next_civ_id(self) -> int:
+        i = 0
+        while i in self.world.civs:
+            i += 1
+        return i
+
+    def _in_bounds(self, c: Coord) -> bool:
+        x, y = c
+        return 0 <= x < self.world.width and 0 <= y < self.world.height
+
+    def advance_week(self) -> None:
+        w = self.world
+        # Production
+        for civ in w.civs.values():
+            gain = 0
+            for (x, y) in civ.tiles:
+                t = w.get_tile(x, y)
+                gain += max(0, t.pop // 2)
+            civ.stock_food += gain
+
+        # Natural growth
+        for t in w.tiles:
+            if t.pop > 0:
+                t.pop += self.rng.choice([0, 0, 1])
+                if t.pop > 9999:
+                    t.pop = 9999
+
+        # Colonization: spend 10 food to claim adjacent unowned tiles, prefer higher pop
+        for civ in w.civs.values():
+            tried = 0
+            frontier: List[Coord] = []
+            for (x, y) in civ.tiles:
+                for nx, ny in w.neighbors4(x, y):
+                    tt = w.get_tile(nx, ny)
+                    if tt.owner is None:
+                        frontier.append((nx, ny))
+            frontier.sort(key=lambda c: w.get_tile(*c).pop, reverse=True)
+            for (fx, fy) in frontier:
+                if civ.stock_food < 10:
+                    break
+                tt = w.get_tile(fx, fy)
+                if tt.owner is None:
+                    tt.owner = civ.civ_id
+                    civ.tiles.append((fx, fy))
+                    civ.stock_food -= 10
+                    tried += 1
+                if tried >= 3:
+                    break
+
+        w.week += 1
+
+    def summary(self) -> Dict:
+        w = self.world
+        pop_total = sum(t.pop for t in w.tiles)
+        owned = sum(1 for t in w.tiles if t.owner is not None)
+        return {
+            "week": w.week,
+            "width": w.width, "height": w.height,
+            "total_pop": pop_total,
+            "owned_tiles": owned,
+            "civs": {
+                cid: {"name": c.name, "tiles": len(c.tiles), "food": c.stock_food}
+                for cid, c in w.civs.items()
+            }
+        }
+
+    def save_json(self, path: str) -> None:
+        w = self.world
+        data = {
+            "width": w.width, "height": w.height, "week": w.week, "seed": w.seed,
+            "tiles": [{"x": t.x, "y": t.y, "pop": t.pop, "owner": t.owner} for t in w.tiles],
+            "civs": {str(cid): {"civ_id": c.civ_id, "name": c.name, "stock_food": c.stock_food, "tiles": c.tiles}
+                     for cid, c in w.civs.items()}
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def load_json(self, path: str) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        w = World(width=data["width"], height=data["height"], tiles=[], civs={}, week=data["week"], seed=data["seed"])
+        tiles = [Tile(x=td["x"], y=td["y"], pop=td["pop"], owner=td["owner"]) for td in data["tiles"]]
+        w.tiles = tiles
+        civs: Dict[int, Civ] = {}
+        for _, cd in data["civs"].items():
+            civ = Civ(civ_id=cd["civ_id"], name=cd["name"], stock_food=cd["stock_food"],
+                      tiles=[tuple(t) for t in cd["tiles"]])
+            civs[civ.civ_id] = civ
+        w.civs = civs
+        self.world = w
+        self.rng = random.Random(w.seed)

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,89 @@
+import sys
+import pygame
+from engine import SimulationEngine
+
+TILE = 16  # pixels
+
+class GameGUI:
+    def __init__(self, world_path: str):
+        pygame.init()
+        self.clock = pygame.time.Clock()
+        self.eng = SimulationEngine()
+        self.eng.load_json(world_path)
+        w, h = self.eng.world.width, self.eng.world.height
+        self.zoom = 1.0
+        self.camera_x = 0
+        self.camera_y = 0
+        self.screen = pygame.display.set_mode((min(1280, w*TILE), min(800, h*TILE)))
+        pygame.display.set_caption("Sim GUI")
+        self.font = pygame.font.SysFont("consolas", 16)
+
+    def world_to_screen(self, x, y):
+        sx = int((x * TILE - self.camera_x) * self.zoom)
+        sy = int((y * TILE - self.camera_y) * self.zoom)
+        return sx, sy
+
+    def run(self):
+        running = True
+        while running:
+            for ev in pygame.event.get():
+                if ev.type == pygame.QUIT:
+                    running = False
+                elif ev.type == pygame.KEYDOWN:
+                    if ev.key == pygame.K_ESCAPE:
+                        running = False
+                    elif ev.key == pygame.K_SPACE:
+                        self.eng.advance_week()
+                    elif ev.key == pygame.K_s and pygame.key.get_mods() & pygame.KMOD_CTRL:
+                        self.eng.save_json("autosave.json")
+                    elif ev.key in (pygame.K_EQUALS, pygame.K_PLUS):
+                        self.zoom = min(4.0, self.zoom * 1.2)
+                    elif ev.key == pygame.K_MINUS:
+                        self.zoom = max(0.25, self.zoom / 1.2)
+
+            keys = pygame.key.get_pressed()
+            pan = 10 / self.zoom
+            if keys[pygame.K_LEFT] or keys[pygame.K_a]:
+                self.camera_x = max(0, self.camera_x - pan)
+            if keys[pygame.K_RIGHT] or keys[pygame.K_d]:
+                self.camera_x = min(self.eng.world.width * TILE, self.camera_x + pan)
+            if keys[pygame.K_UP] or keys[pygame.K_w]:
+                self.camera_y = max(0, self.camera_y - pan)
+            if keys[pygame.K_DOWN] or keys[pygame.K_s]:
+                self.camera_y = min(self.eng.world.height * TILE, self.camera_y + pan)
+
+            self.draw()
+            pygame.display.flip()
+            self.clock.tick(60)
+        pygame.quit()
+        sys.exit(0)
+
+    def draw(self):
+        scr = self.screen
+        scr.fill((8, 8, 12))
+        w = self.eng.world
+        size = int(TILE * self.zoom)
+
+        for t in w.tiles:
+            sx, sy = self.world_to_screen(t.x, t.y)
+            if sx + size < 0 or sy + size < 0 or sx > scr.get_width() or sy > scr.get_height():
+                continue
+            if t.owner is None:
+                base = (60, 60, 60)
+            else:
+                ci = (t.owner * 97) % 255
+                base = (40 + ci//2, 80, 120)
+            b = min(200, 40 + (t.pop // 2))
+            color = (min(255, base[0] + b//6), min(255, base[1] + b//6), min(255, base[2] + b//6))
+            pygame.draw.rect(scr, color, (sx, sy, size-1, size-1))
+
+        summary = self.eng.summary()
+        text = f"Week {summary['week']} | Tiles owned: {summary['owned_tiles']} | Total pop: {summary['total_pop']}"
+        hud = self.font.render(text, True, (240, 240, 240))
+        scr.blit(hud, (8, 8))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python gui.py path/to/world.json")
+        sys.exit(1)
+    GameGUI(sys.argv[1]).run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy
 Pillow
+pygame
+pytest

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,27 @@
+import os
+from engine import SimulationEngine
+
+def test_end_to_end(tmp_path):
+    world_path = tmp_path / "world.json"
+    eng = SimulationEngine(width=32, height=20, seed=7)
+    eng.seed_population_everywhere(min_pop=5, max_pop=15)
+    eng.add_civ("A", (5, 5))
+    eng.add_civ("B", (20, 10))
+    eng.save_json(str(world_path))
+
+    eng2 = SimulationEngine()
+    eng2.load_json(str(world_path))
+    for _ in range(100):
+        eng2.advance_week()
+
+    s = eng2.summary()
+    assert s["week"] == 100
+    assert s["total_pop"] > 0
+    for _, info in s["civs"].items():
+        assert info["tiles"] >= 1
+
+    out = tmp_path / "world_after.json"
+    eng2.save_json(str(out))
+    eng3 = SimulationEngine()
+    eng3.load_json(str(out))
+    assert eng3.summary()["total_pop"] == s["total_pop"]


### PR DESCRIPTION
## Summary
- add deterministic SimulationEngine with civ growth and colonization
- create CLI utilities for world creation, stepping, summaries, and autoplay
- implement pygame GUI with pan/zoom and saving
- add autoplay bot helper and end-to-end pytest

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sim')*
- `PYTHONPATH=. pytest tests/test_e2e.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b711fc8080832c9fc1f4beda788acb