### PR TITLE
Add sim compatibility shim and pytest config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = .
+addopts = -q
+testpaths = tests

--- a/sim/__init__.py
+++ b/sim/__init__.py
@@ -1,0 +1,14 @@
+"""
+Compatibility shim so legacy code/tests that do `import sim` keep working.
+Re-exports the new engine types implemented in engine.py.
+"""
+from typing import Any
+from engine import SimulationEngine, World, Tile, Civ
+
+__all__ = ["SimulationEngine", "World", "Tile", "Civ"]
+
+def __getattr__(name: str) -> Any:
+    # Only expose known symbols; fail clearly for anything else.
+    if name in __all__:
+        return globals()[name]
+    raise AttributeError(f"module 'sim' has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- provide `sim` package that re-exports new engine
- add pytest.ini so tests run without PYTHONPATH tweaks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71557484c832c8bce79e5c673a234