### PR TITLE
Introduce calendar-based time model

### DIFF
--- a/bots/autoplay.py
+++ b/bots/autoplay.py
@@ -4,7 +4,7 @@ def run(world_path: str, weeks: int = 52, save_path: str | None = None) -> dict:
     eng = SimulationEngine()
     eng.load_json(world_path)
     for _ in range(weeks):
-        eng.advance_week()
+        eng.advance_turn()
     if save_path:
         eng.save_json(save_path)
     return eng.summary()

--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,7 @@ def cmd_step(args):
     eng = SimulationEngine()
     eng.load_json(args.world)
     for _ in range(args.weeks):
-        eng.advance_week()
+        eng.advance_turn()
     if args.save:
         eng.save_json(args.save)
         print(f"Saved to {args.save}")
@@ -31,7 +31,7 @@ def cmd_autoplay(args):
     eng = SimulationEngine()
     eng.load_json(args.world)
     for _ in range(args.weeks):
-        eng.advance_week()
+        eng.advance_turn()
     if args.save:
         eng.save_json(args.save)
         print(f"Saved to {args.save}")
@@ -51,7 +51,7 @@ def main():
     ap_new.add_argument("--out", default="world.json")
     ap_new.set_defaults(func=cmd_new)
 
-    ap_step = sub.add_parser("step", help="Advance weeks and print summary")
+    ap_step = sub.add_parser("step", help="Advance turns and print summary")
     ap_step.add_argument("world")
     ap_step.add_argument("--weeks", type=int, default=1)
     ap_step.add_argument("--save", default=None)
@@ -61,7 +61,7 @@ def main():
     ap_sum.add_argument("world")
     ap_sum.set_defaults(func=cmd_summary)
 
-    ap_auto = sub.add_parser("autoplay", help="Run a bot for N weeks")
+    ap_auto = sub.add_parser("autoplay", help="Run a bot for N turns")
     ap_auto.add_argument("world")
     ap_auto.add_argument("--weeks", type=int, default=52)
     ap_auto.add_argument("--save", default=None)

--- a/gui.py
+++ b/gui.py
@@ -33,7 +33,7 @@ class GameGUI:
                     if ev.key == pygame.K_ESCAPE:
                         running = False
                     elif ev.key == pygame.K_SPACE:
-                        self.eng.advance_week()
+                        self.eng.advance_turn()
                     elif ev.key == pygame.K_s and pygame.key.get_mods() & pygame.KMOD_CTRL:
                         self.eng.save_json("autosave.json")
                     elif ev.key in (pygame.K_EQUALS, pygame.K_PLUS):
@@ -78,7 +78,7 @@ class GameGUI:
             pygame.draw.rect(scr, color, (sx, sy, size-1, size-1))
 
         summary = self.eng.summary()
-        text = f"Week {summary['week']} | Tiles owned: {summary['owned_tiles']} | Total pop: {summary['total_pop']}"
+        text = f"Turn {summary['turn']} | Tiles owned: {summary['owned_tiles']} | Total pop: {summary['total_pop']}"
         hud = self.font.render(text, True, (240, 240, 240))
         scr.blit(hud, (8, 8))
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,13 @@
+from engine import SimulationEngine
+
+
+def test_weekly_steps_about_one_year():
+    eng = SimulationEngine()
+    for _ in range(52):
+        eng.advance_turn()
+    cal = eng.world.calendar
+    assert cal.year == 0
+    assert cal.month == 12
+    assert cal.day >= 24
+    eng.advance_turn()
+    assert eng.world.calendar.year >= 1

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,10 +12,10 @@ def test_end_to_end(tmp_path):
     eng2 = SimulationEngine()
     eng2.load_json(str(world_path))
     for _ in range(100):
-        eng2.advance_week()
+        eng2.advance_turn()
 
     s = eng2.summary()
-    assert s["week"] == 100
+    assert s["turn"] == 100
     assert s["total_pop"] > 0
     for _, info in s["civs"].items():
         assert info["tiles"] >= 1

--- a/time_model.py
+++ b/time_model.py
@@ -1,0 +1,30 @@
+"""Time scale constants and calendar utilities."""
+from __future__ import annotations
+from dataclasses import dataclass
+
+# Fraction of a year per time scale
+WEEK = 1 / 52
+MONTH = 1 / 12
+YEAR = 1.0
+
+DAYS_PER_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+@dataclass
+class Calendar:
+    year: int = 0
+    month: int = 1
+    day: int = 1
+
+    def advance_fraction(self, delta_years: float) -> None:
+        """Advance the calendar by ``delta_years``."""
+        days = int(round(delta_years * 365))
+        self.day += days
+        while True:
+            dim = DAYS_PER_MONTH[self.month - 1]
+            if self.day <= dim:
+                break
+            self.day -= dim
+            self.month += 1
+            if self.month > 12:
+                self.month = 1
+                self.year += 1


### PR DESCRIPTION
## Summary
- add `time_model` module with week, month, year constants and a simple `Calendar`
- support variable time scale in `SimulationEngine` with new `advance_turn` and calendar tracking
- update CLI, GUI, and bots to use turn-based stepping and add tests for week-to-year progression

## Testing
- `python -m py_compile engine.py time_model.py cli.py gui.py bots/autoplay.py tests/test_e2e.py tests/test_calendar.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71bc32e30832c812fab6bc1df64e2