### PR TITLE
Add armies with pathfinding, supply, and combat

### DIFF
--- a/pathfinding.py
+++ b/pathfinding.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from typing import List, Tuple, Dict, Optional
+import heapq
+from hexgrid import distance
+
+Coord = Tuple[int, int]
+
+
+def terrain_cost(world, q: int, r: int) -> int:
+    t = world.get_tile(q, r)
+    if t.biome == "ocean":
+        return 50
+    if t.biome == "mountain":
+        return 5
+    return 1
+
+
+def reconstruct(came_from: Dict[Coord, Coord], current: Coord) -> List[Coord]:
+    path = [current]
+    while current in came_from:
+        current = came_from[current]
+        path.append(current)
+    path.reverse()
+    return path
+
+
+def astar(world, start: Coord, goal: Coord) -> List[Coord]:
+    if start == goal:
+        return []
+    open_heap: List[Tuple[float, Coord]] = []
+    heapq.heappush(open_heap, (0.0, start))
+    came_from: Dict[Coord, Coord] = {}
+    g_score: Dict[Coord, float] = {start: 0.0}
+    closed: set[Coord] = set()
+    while open_heap:
+        _, current = heapq.heappop(open_heap)
+        if current == goal:
+            full_path = reconstruct(came_from, current)
+            return full_path[1:]
+        if current in closed:
+            continue
+        closed.add(current)
+        for neighbor in world.neighbors6(*current):
+            tentative = g_score[current] + terrain_cost(world, *neighbor)
+            if tentative < g_score.get(neighbor, float("inf")):
+                came_from[neighbor] = current
+                g_score[neighbor] = tentative
+                f = tentative + distance(neighbor[0], neighbor[1], goal[0], goal[1])
+                heapq.heappush(open_heap, (f, neighbor))
+    return []

--- a/tests/test_armies.py
+++ b/tests/test_armies.py
@@ -1,0 +1,48 @@
+from engine import SimulationEngine
+
+
+def setup_world(width=6, height=6, seed=1):
+    e = SimulationEngine(width=width, height=height, seed=seed)
+    for t in e.world.tiles:
+        t.biome = "grass"
+    return e
+
+
+def test_army_pathfinding_and_movement():
+    e = setup_world()
+    e.world.get_tile(1, 0).biome = "mountain"
+    cid = e.add_civ("A", (0, 0))
+    army = e.add_army(cid, (0, 0), strength=5)
+    e.set_army_target(army, (2, 0))
+    e.advance_turn()  # week
+    assert (army.q, army.r) == (0, 1)
+    e.advance_turn()
+    assert (army.q, army.r) == (1, 1)
+    e.advance_turn()
+    assert (army.q, army.r) == (2, 0)
+
+
+def test_supply_attrition_and_no_negative_strength():
+    e = SimulationEngine(width=4, height=4, seed=1)
+    tile = e.world.get_tile(0, 0)
+    tile.biome = "mountain"
+    cid = e.add_civ("A", (0, 0))
+    army = e.add_army(cid, (0, 0), strength=2, supply=1)
+    e.advance_turn()
+    assert army.supply == 0
+    assert army.strength == 1
+    e.advance_turn()
+    assert len(e.world.armies) == 0
+
+
+def test_combat_resolution():
+    e = SimulationEngine(width=4, height=4, seed=1)
+    e.world.get_tile(0, 0).biome = "grass"
+    cid1 = e.add_civ("A", (0, 0))
+    cid2 = e.add_civ("B", (0, 0))
+    a1 = e.add_army(cid1, (0, 0), strength=10)
+    a2 = e.add_army(cid2, (0, 0), strength=6)
+    e.advance_turn()
+    assert len(e.world.armies) == 1
+    assert e.world.armies[0].civ_id == cid1
+    assert e.world.armies[0].strength == 7


### PR DESCRIPTION
## Summary
- introduce Army dataclass with supply and movement attributes
- implement hex-grid A* pathfinding with terrain costs
- move armies along paths with supply attrition and resolve combat
- persist armies in save/load and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b726118bac832ca85af8981f030702