### PR TITLE
feat: expand CLI with time controls and REPL

### DIFF
--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -18,6 +18,7 @@ def test_cli_export_writes_images(tmp_path):
         "python",
         "cli.py",
         "export",
+        "--world",
         str(world_path),
         "--topdown",
         str(top_path),

--- a/tests/test_cli_time_commands.py
+++ b/tests/test_cli_time_commands.py
@@ -1,0 +1,42 @@
+import subprocess
+
+from engine import SimulationEngine
+
+
+def test_cli_set_timescale(tmp_path):
+    world_path = tmp_path / "world.json"
+    eng = SimulationEngine()
+    eng.save_json(str(world_path))
+    subprocess.run([
+        "python",
+        "cli.py",
+        "set-timescale",
+        str(world_path),
+        "month",
+    ], check=True)
+    eng2 = SimulationEngine()
+    eng2.load_json(str(world_path))
+    assert eng2.world.time_scale == "month"
+
+
+def test_cli_set_date_clamps(tmp_path):
+    world_path = tmp_path / "world.json"
+    eng = SimulationEngine()
+    eng.save_json(str(world_path))
+    subprocess.run([
+        "python",
+        "cli.py",
+        "set-date",
+        str(world_path),
+        "--year",
+        "1",
+        "--month",
+        "13",
+        "--day",
+        "40",
+    ], check=True)
+    eng2 = SimulationEngine()
+    eng2.load_json(str(world_path))
+    assert eng2.world.calendar.year == 1
+    assert eng2.world.calendar.month == 12
+    assert eng2.world.calendar.day == 31


### PR DESCRIPTION
## Summary
- allow world creation to tweak hex size and worldgen parameters
- add `set-timescale` and `set-date` commands plus export arg updates
- introduce interactive `repl` for stepping and army control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b72b7a14f0832ca14a880be54b7d90