### PR TITLE
GUI: hex rendering and interactions

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,89 +1,238 @@
-import sys
-import pygame
-from engine import SimulationEngine
+"""Simple Pygame GUI for interacting with the simulation world."""
 
-TILE = 16  # pixels
+from __future__ import annotations
+
+import sys
+from typing import Optional, Tuple
+
+import pygame
+
+from engine import SimulationEngine, Army
+from hexgrid import axial_to_pixel, hex_polygon, pixel_to_axial
+
+# Biome colors roughly matching ``render.py``
+BIOME_COLORS = [
+    (int(0.20 * 255), int(0.70 * 255), int(0.20 * 255)),  # grass/land
+    (int(0.95 * 255), int(0.85 * 255), int(0.25 * 255)),  # sand/coast
+    (int(0.60 * 255), int(0.60 * 255), int(0.60 * 255)),  # mountain
+    (int(0.05 * 255), int(0.15 * 255), int(0.45 * 255)),  # ocean
+]
+
+# Ownership tint colors
+OWNER_TINTS = [
+    (255, 0, 0),
+    (0, 0, 255),
+    (255, 255, 0),
+    (255, 0, 255),
+    (0, 255, 255),
+    (255, 165, 0),
+]
+
 
 class GameGUI:
-    def __init__(self, world_path: str):
+    """Interactive hex-map GUI with basic controls."""
+
+    def __init__(self, world_path: str) -> None:
         pygame.init()
         self.clock = pygame.time.Clock()
+
         self.eng = SimulationEngine()
         self.eng.load_json(world_path)
-        w, h = self.eng.world.width, self.eng.world.height
+
+        self.hex_px = 24  # base hex radius in pixels
         self.zoom = 1.0
-        self.camera_x = 0
-        self.camera_y = 0
-        self.screen = pygame.display.set_mode((min(1280, w*TILE), min(800, h*TILE)))
+        self.camera_x = 0.0
+        self.camera_y = 0.0
+
+        self.screen = pygame.display.set_mode((1280, 800))
         pygame.display.set_caption("Sim GUI")
         self.font = pygame.font.SysFont("consolas", 16)
 
-    def world_to_screen(self, x, y):
-        sx = int((x * TILE - self.camera_x) * self.zoom)
-        sy = int((y * TILE - self.camera_y) * self.zoom)
+        self.selected_hex: Optional[Tuple[int, int]] = None
+        self.selected_army: Optional[Army] = None
+
+        # Pre-compute world bounds in pixel space for camera clamping
+        w = self.eng.world
+        xs, ys = [], []
+        for (q, r) in (
+            (0, 0),
+            (w.width_hex - 1, 0),
+            (0, w.height_hex - 1),
+            (w.width_hex - 1, w.height_hex - 1),
+        ):
+            x, y = axial_to_pixel(q, r, self.hex_px)
+            xs.extend([x - self.hex_px, x + self.hex_px])
+            ys.extend([y - self.hex_px, y + self.hex_px])
+        self.world_w = max(xs) if xs else 0.0
+        self.world_h = max(ys) if ys else 0.0
+
+    # ------------------------------------------------------------------ utils --
+    def clamp_camera(self) -> None:
+        sw, sh = self.screen.get_size()
+        max_x = max(0.0, self.world_w - sw / self.zoom)
+        max_y = max(0.0, self.world_h - sh / self.zoom)
+        if self.camera_x < 0.0:
+            self.camera_x = 0.0
+        elif self.camera_x > max_x:
+            self.camera_x = max_x
+        if self.camera_y < 0.0:
+            self.camera_y = 0.0
+        elif self.camera_y > max_y:
+            self.camera_y = max_y
+
+    def world_to_screen(self, x: float, y: float) -> Tuple[int, int]:
+        sx = int((x - self.camera_x) * self.zoom)
+        sy = int((y - self.camera_y) * self.zoom)
         return sx, sy
 
-    def run(self):
+    def screen_to_hex(self, sx: int, sy: int) -> Tuple[int, int]:
+        wx = sx / self.zoom + self.camera_x
+        wy = sy / self.zoom + self.camera_y
+        return pixel_to_axial(wx, wy, self.hex_px)
+
+    def tile_color(self, tile) -> Tuple[int, int, int]:
+        try:
+            b = int(tile.biome)
+        except Exception:
+            b = 0
+        base = BIOME_COLORS[b % len(BIOME_COLORS)]
+        # Brightness from population (0 -> 0.3, high pop -> 1.0)
+        k = min(1.0, 0.3 + tile.pop / 200.0)
+        col = tuple(min(255, int(c * k)) for c in base)
+        if tile.owner is not None:
+            tint = OWNER_TINTS[tile.owner % len(OWNER_TINTS)]
+            col = tuple(min(255, (c + t) // 2) for c, t in zip(col, tint))
+        return col
+
+    # ----------------------------------------------------------------- events --
+    def handle_mouse(self, ev: pygame.event.Event) -> None:
+        if ev.button == 1:  # left click select
+            q, r = self.screen_to_hex(*ev.pos)
+            if self.eng.world.in_bounds(q, r):
+                self.selected_hex = (q, r)
+                self.selected_army = None
+                for a in self.eng.world.armies:
+                    if a.q == q and a.r == r:
+                        self.selected_army = a
+                        break
+        elif ev.button == 3:  # right click set army target
+            if self.selected_army is None:
+                return
+            q, r = self.screen_to_hex(*ev.pos)
+            if self.eng.world.in_bounds(q, r):
+                self.eng.set_army_target(self.selected_army, (q, r))
+
+    def handle_key(self, ev: pygame.event.Event) -> None:
+        if ev.key == pygame.K_ESCAPE:
+            pygame.quit()
+            sys.exit(0)
+        elif ev.key == pygame.K_SPACE:
+            self.eng.advance_turn()
+        elif ev.key == pygame.K_s and pygame.key.get_mods() & pygame.KMOD_CTRL:
+            self.eng.save_json("autosave.json")
+        elif ev.key in (pygame.K_EQUALS, pygame.K_PLUS):
+            self.zoom = min(4.0, self.zoom * 1.2)
+            self.clamp_camera()
+        elif ev.key == pygame.K_MINUS:
+            self.zoom = max(0.25, self.zoom / 1.2)
+            self.clamp_camera()
+        elif ev.key == pygame.K_a and self.selected_hex is not None:
+            q, r = self.selected_hex
+            t = self.eng.world.get_tile(q, r)
+            if t.owner is not None:
+                self.selected_army = self.eng.add_army(t.owner, (q, r))
+
+    # ------------------------------------------------------------------- main --
+    def run(self) -> None:
         running = True
         while running:
             for ev in pygame.event.get():
                 if ev.type == pygame.QUIT:
                     running = False
                 elif ev.type == pygame.KEYDOWN:
-                    if ev.key == pygame.K_ESCAPE:
-                        running = False
-                    elif ev.key == pygame.K_SPACE:
-                        self.eng.advance_turn()
-                    elif ev.key == pygame.K_s and pygame.key.get_mods() & pygame.KMOD_CTRL:
-                        self.eng.save_json("autosave.json")
-                    elif ev.key in (pygame.K_EQUALS, pygame.K_PLUS):
-                        self.zoom = min(4.0, self.zoom * 1.2)
-                    elif ev.key == pygame.K_MINUS:
-                        self.zoom = max(0.25, self.zoom / 1.2)
+                    self.handle_key(ev)
+                elif ev.type == pygame.MOUSEBUTTONDOWN:
+                    self.handle_mouse(ev)
 
             keys = pygame.key.get_pressed()
-            pan = 10 / self.zoom
+            pan = 10.0 / self.zoom
             if keys[pygame.K_LEFT] or keys[pygame.K_a]:
-                self.camera_x = max(0, self.camera_x - pan)
+                self.camera_x -= pan
             if keys[pygame.K_RIGHT] or keys[pygame.K_d]:
-                self.camera_x = min(self.eng.world.width * TILE, self.camera_x + pan)
+                self.camera_x += pan
             if keys[pygame.K_UP] or keys[pygame.K_w]:
-                self.camera_y = max(0, self.camera_y - pan)
+                self.camera_y -= pan
             if keys[pygame.K_DOWN] or keys[pygame.K_s]:
-                self.camera_y = min(self.eng.world.height * TILE, self.camera_y + pan)
+                self.camera_y += pan
+            self.clamp_camera()
 
             self.draw()
             pygame.display.flip()
             self.clock.tick(60)
+
         pygame.quit()
         sys.exit(0)
 
-    def draw(self):
+    # ------------------------------------------------------------------- draw --
+    def draw(self) -> None:
         scr = self.screen
         scr.fill((8, 8, 12))
         w = self.eng.world
-        size = int(TILE * self.zoom)
+        zoom = self.zoom
+        sw, sh = scr.get_size()
 
         for t in w.tiles:
-            sx, sy = self.world_to_screen(t.x, t.y)
-            if sx + size < 0 or sy + size < 0 or sx > scr.get_width() or sy > scr.get_height():
+            cx, cy = axial_to_pixel(t.q, t.r, self.hex_px)
+            sx, sy = self.world_to_screen(cx, cy)
+            size = self.hex_px * zoom
+            if (
+                sx + size < 0
+                or sy + size < 0
+                or sx - size > sw
+                or sy - size > sh
+            ):
                 continue
-            if t.owner is None:
-                base = (60, 60, 60)
-            else:
-                ci = (t.owner * 97) % 255
-                base = (40 + ci//2, 80, 120)
-            b = min(200, 40 + (t.pop // 2))
-            color = (min(255, base[0] + b//6), min(255, base[1] + b//6), min(255, base[2] + b//6))
-            pygame.draw.rect(scr, color, (sx, sy, size-1, size-1))
 
-        summary = self.eng.summary()
-        text = f"Turn {summary['turn']} | Tiles owned: {summary['owned_tiles']} | Total pop: {summary['total_pop']}"
-        hud = self.font.render(text, True, (240, 240, 240))
+            pts = hex_polygon(t.q, t.r, self.hex_px)
+            pts = [self.world_to_screen(px, py) for px, py in pts]
+            pygame.draw.polygon(scr, self.tile_color(t), pts)
+            if self.selected_hex == (t.q, t.r):
+                pygame.draw.polygon(scr, (255, 255, 255), pts, 2)
+
+        for a in w.armies:
+            cx, cy = axial_to_pixel(a.q, a.r, self.hex_px)
+            sx, sy = self.world_to_screen(cx, cy)
+            if sx < -10 or sy < -10 or sx > sw + 10 or sy > sh + 10:
+                continue
+            col = OWNER_TINTS[a.civ_id % len(OWNER_TINTS)]
+            rad = int(self.hex_px * 0.3 * zoom)
+            pygame.draw.circle(scr, (0, 0, 0), (sx, sy), rad + 2)
+            pygame.draw.circle(scr, col, (sx, sy), rad)
+            if a is self.selected_army:
+                pygame.draw.circle(scr, (255, 255, 255), (sx, sy), rad + 3, 2)
+
+        # HUD -----------------------------------------------------------------
+        date = self.eng.world.calendar
+        dstr = f"{date.year:04d}-{date.month:02d}-{date.day:02d}"
+        hud_parts = [f"{dstr}", f"scale:{self.eng.world.time_scale}"]
+        if self.selected_hex is not None:
+            q, r = self.selected_hex
+            t = self.eng.world.get_tile(q, r)
+            hud_parts.append(
+                f"hex({q},{r}) biome:{t.biome} pop:{t.pop} owner:{t.owner}"
+            )
+        if self.selected_army is not None and self.selected_army in w.armies:
+            aid = w.armies.index(self.selected_army)
+            hud_parts.append(
+                f"army{aid} str:{self.selected_army.strength} tgt:{self.selected_army.target}"
+            )
+        hud = self.font.render(" | ".join(hud_parts), True, (240, 240, 240))
         scr.blit(hud, (8, 8))
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python gui.py path/to/world.json")
         sys.exit(1)
     GameGUI(sys.argv[1]).run()
+

--- a/hexgrid.py
+++ b/hexgrid.py
@@ -28,6 +28,40 @@ def axial_to_pixel(q: int, r: int, hex_size: float) -> Tuple[float, float]:
     y = SQRT3 * hex_size * (r + 0.5 * q)
     return x, y
 
+
+def pixel_to_axial(x: float, y: float, hex_size: float) -> Tuple[int, int]:
+    """Approximate inverse of :func:`axial_to_pixel` for flat-top hexes.
+
+    The returned axial coordinates are rounded to the nearest hex tile.
+    ``hex_size`` must match the size used in :func:`axial_to_pixel`.
+    """
+
+    if hex_size == 0:
+        raise ValueError("hex_size must be non-zero")
+
+    # Fractional axial coordinates
+    fq = (2.0 / 3.0) * x / hex_size
+    fr = ((-1.0 / 3.0) * x + (SQRT3 / 3.0) * y) / hex_size
+
+    # Convert to cube and round to nearest
+    fs = -fq - fr
+    rq = round(fq)
+    rr = round(fr)
+    rs = round(fs)
+
+    dq = abs(rq - fq)
+    dr = abs(rr - fr)
+    ds = abs(rs - fs)
+
+    if dq > dr and dq > ds:
+        rq = -rr - rs
+    elif dr > ds:
+        rr = -rq - rs
+    else:
+        rs = -rq - rr
+
+    return int(rq), int(rr)
+
 # Alias used by worldgen/render code
 axial_to_world_flat = axial_to_pixel
 


### PR DESCRIPTION
## Summary
- Draw world hexes as filled polygons colored by biome/ownership
- Add helper to convert pixel coordinates back to axial hex coords
- Support selecting hexes and armies, spawning and ordering armies, and show HUD with date and selection info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b72d3612a4832c8d68b7f67dcf695b