### PR TITLE
Fix army movement and biome handling

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -92,7 +92,9 @@ class Army:
     target: Optional[Coord] = None
     path: List[Coord] = field(default_factory=list)
     supply: int = 100
-    speed_hexes_per_year: int = 12
+    # Default movement speed tuned so that an army advances roughly
+    # one hex per weekly turn. 52 hexes/year = 1 hex/week.
+    speed_hexes_per_year: int = 52
     _movement_accumulator: float = field(default=0.0, init=False)
 
 
@@ -413,7 +415,12 @@ class SimulationEngine:
                 min_dist = min(hex_distance(army.q, army.r, tq, tr) for tq, tr in civ_tiles)
             else:
                 min_dist = float("inf")
-            if tile.biome == Biome.MOUNTAIN or min_dist > 5:
+            biome = tile.biome
+            if isinstance(biome, Biome):
+                is_mountain = biome == Biome.MOUNTAIN
+            else:
+                is_mountain = str(biome).lower() == "mountain"
+            if is_mountain or min_dist > 5:
                 army.supply = max(0, army.supply - 1)
                 if army.supply <= 0:
                     army.strength = max(0, army.strength - 1)

--- a/pathfinding.py
+++ b/pathfinding.py
@@ -1,16 +1,27 @@
-from __future__ import annotations
-from typing import List, Tuple, Dict, Optional
 import heapq
+from typing import Dict, List, Tuple
+
+from worldgen.biomes import Biome
 from worldgen.hexgrid import distance
 
 Coord = Tuple[int, int]
 
 
+def _biome_name(tile) -> str:
+    """Return biome name as lowercase string for tiles that may store
+    either the Biome enum or raw strings."""
+    b = tile.biome
+    if isinstance(b, Biome):
+        return b.name.lower()
+    return str(b).lower()
+
+
 def terrain_cost(world, q: int, r: int) -> int:
     t = world.get_tile(q, r)
-    if t.biome == "ocean":
+    biome = _biome_name(t)
+    if biome == "ocean":
         return 50
-    if t.biome == "mountain":
+    if biome == "mountain":
         return 5
     return 1
 


### PR DESCRIPTION
## Summary
- Make armies move one hex per week by default
- Account for string and enum biomes when computing army attrition
- Normalize biome lookups in pathfinding

## Testing
- `pytest tests/test_armies.py::test_army_pathfinding_and_movement tests/test_armies.py::test_supply_attrition_and_no_negative_strength -q`
- `pytest -q` *(fails: ValueError invalid literal for int() with base 10: 'mountain', ModuleNotFoundError: No module named 'engine_integration', and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b95de949f0832ca60e6bffa56feb0d