### PR TITLE
Add expandable civ info panel and tech tree hotkey

### DIFF
--- a/fixes/cohort_integration.py
+++ b/fixes/cohort_integration.py
@@ -2,7 +2,7 @@
 """Integration of the age cohort system into the main game."""
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 import numpy as np
 from sim.cohorts import (
     init_from_total, step_cohorts, totals_from_cohorts,


### PR DESCRIPTION
## Summary
- Rework info GUI into expandable panel with civ details and selector
- Enable T key to open the technology tree for the currently viewed civ
- Fix missing typing import in cohort integration helper

## Testing
- `PYTHONPATH=fixes pytest` *(fails: NameError: name 'engine' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bbe8b4b8832c82483244e27ccd4b