### PR TITLE
Fix colonization neighbor logic for even-q grids

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -484,7 +484,7 @@ class SimulationEngine:
             src.pop = max(0, src.pop - SETTLER_COST)
             src._pop_float = float(src.pop)
             dst.owner = cid
-            dst.pop = max(SETTLER_COST, 15)  # Ensure new settlements start with at least 15 population for faster growth
+            dst.pop = SETTLER_COST
             dst._pop_float = float(dst.pop)
             civ.tiles.append((dq, dr))
 


### PR DESCRIPTION
## Summary
- Use even-q neighbor calculations in simulation to match flat-top hex grid
- Seed new colonies with settler-cost population in both simulation and engine logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baba964620832c988cfbea6e1300b4