### PR TITLE
Centralize simulation modifiers in shared config

### DIFF
--- a/fixes/military_economy.py
+++ b/fixes/military_economy.py
@@ -7,6 +7,8 @@ from enum import Enum
 import math
 import numpy as np
 
+from modifiers import MODIFIERS
+
 class SupplySource(Enum):
     """Types of supply sources for armies."""
     CAPITAL = "capital"
@@ -37,9 +39,11 @@ class MilitaryEconomy:
     """Manages all military-economic interactions."""
     
     # Food economy
-    food_per_pop_per_year: float = 1.0
-    food_per_soldier_per_year: float = 1.5  # Soldiers eat more
-    army_creation_food_cost_multiplier: float = 3.0  # Initial equipment/training
+    food_per_pop_per_year: float = MODIFIERS.food_per_pop_per_year
+    food_per_soldier_per_year: float = MODIFIERS.food_per_soldier_per_year  # Soldiers eat more
+    army_creation_food_cost_multiplier: float = (
+        MODIFIERS.army_creation_food_cost_multiplier
+    )  # Initial equipment/training
     
     # Maintenance costs
     gold_per_soldier_per_year: float = 2.0

--- a/modifiers.py
+++ b/modifiers.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class GameModifiers:
+    """Tweakable simulation parameters.
+
+    Central store for values that affect core simulation mechanics.
+    Events or technologies can modify these numbers at runtime to
+    globally influence systems that consume them.
+    """
+
+    # Carrying capacity derived from food supply
+    carrying_capacity_per_food: float = 100.0
+    min_food_eps: float = 1e-6
+
+    # Population dynamics
+    base_population_growth_rate: float = 0.04  # logistic growth per year
+    growth_variance: float = 0.2
+    food_per_pop: float = 1.0
+    disaster_rate: float = 0.02
+
+    # Military and economic costs
+    food_per_pop_per_year: float = 1.0
+    food_per_soldier_per_year: float = 1.5
+    army_creation_food_cost_multiplier: float = 3.0
+
+
+# Global modifiers instance used throughout the codebase
+MODIFIERS = GameModifiers()
+

--- a/sim/loop.py
+++ b/sim/loop.py
@@ -5,10 +5,11 @@ import numpy as np
 from .resources import yields_with_features, carrying_capacity
 from .time import scale_to_years, step_date
 from .settlements import (
-    apply_urban_pressure, apply_growth_bonuses, 
+    apply_urban_pressure, apply_growth_bonuses,
     get_settlement_upgrade_candidate, enforce_settlement_population_hierarchy,
     get_evenq_hex_neighbors, SETTLEMENT_CONFIG
 )
+from modifiers import MODIFIERS
 
 
 def advance_turn(
@@ -16,10 +17,10 @@ def advance_turn(
     *,
     feature_map=None,
     rng_seed=None,
-    growth_rate: float = 0.04,
-    growth_variance: float = 0.2,
-    food_per_pop: float = 1.0,
-    disaster_rate: float = 0.02,
+    growth_rate: float | None = None,
+    growth_variance: float | None = None,
+    food_per_pop: float | None = None,
+    disaster_rate: float | None = None,
     min_settle_pop: float = 25.0,
     settler_cost: float = 10.0,
     pressure_threshold: float = 0.7,
@@ -62,6 +63,15 @@ def advance_turn(
         step_count = int(steps)
 
     dt_years = scale_to_years(ws.time_scale) * max(1, step_count)
+
+    if growth_rate is None:
+        growth_rate = MODIFIERS.base_population_growth_rate
+    if growth_variance is None:
+        growth_variance = MODIFIERS.growth_variance
+    if food_per_pop is None:
+        food_per_pop = MODIFIERS.food_per_pop
+    if disaster_rate is None:
+        disaster_rate = MODIFIERS.disaster_rate
 
     if ws.paused and steps > 0:
         return ws

--- a/systems/colonization_enhanced.py
+++ b/systems/colonization_enhanced.py
@@ -20,6 +20,7 @@ import math
 import numpy as np
 
 import config_colonization as C
+from modifiers import MODIFIERS
 
 
 # ----------- Strategy Enum ----------------------------------------------------
@@ -127,7 +128,10 @@ class EnhancedColonizationSystem:
         pop = float(getattr(t, "_pop_float", getattr(t, "pop", 0.0)))
 
         food, prod = _yields_for(t)
-        cap_per_food = max(C.MIN_FOOD_EPS, C.CARRYING_CAP_PER_FOOD * max(food, 0.0))
+        cap_per_food = max(
+            MODIFIERS.min_food_eps,
+            MODIFIERS.carrying_capacity_per_food * max(food, 0.0),
+        )
         crowding = pop / cap_per_food
 
         # Push factors (crowding)

--- a/systems/config_colonization.py
+++ b/systems/config_colonization.py
@@ -3,6 +3,8 @@ Colonization & Migration tuning knobs.
 Safe to tweak without touching system code.
 """
 
+from modifiers import MODIFIERS
+
 # Global pace multiplier: 0.5 = slower, 2.0 = faster
 PACE_MULTIPLIER: float = 1.0
 
@@ -18,8 +20,8 @@ COLONIZE_SOURCE_MIN_POP: int = 60
 COLONIZE_COLONY_SEED: int = 15
 
 # Carrying capacity
-CARRYING_CAP_PER_FOOD: float = 100.0
-MIN_FOOD_EPS: float = 1e-6  # avoid div-by-zero on barren tiles
+CARRYING_CAP_PER_FOOD: float = MODIFIERS.carrying_capacity_per_food
+MIN_FOOD_EPS: float = MODIFIERS.min_food_eps  # avoid div-by-zero on barren tiles
 
 # Trade routes
 TRADE_ROUTE_MIN_DIST: int = 5


### PR DESCRIPTION
## Summary
- add `modifiers.py` as the single source of tweakable simulation parameters
- read food, growth and carrying capacity constants from this config across systems
- hook colonization and military economy into the shared modifiers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bac9cd0380832ca176ea14225e5e46