### PR TITLE
Add trade goods system with tin and remove old metal resources

### DIFF
--- a/tests/test_technology_resources.py
+++ b/tests/test_technology_resources.py
@@ -1,0 +1,19 @@
+import pytest
+from technology import TechnologySystem, Age
+
+
+def test_age_advancement_does_not_require_metal_resources():
+    ts = TechnologySystem()
+    civ = ts.initialize_civ(1)
+
+    # Meet tech requirement for Copper Age; no resources needed
+    civ.researched_techs = {f"t{i}" for i in range(Age.COPPER.min_techs_required)}
+    assert civ.can_advance_age(ts.tech_tree)
+    assert civ.advance_age()
+    assert civ.current_age == Age.COPPER
+
+    # Set up for Bronze Age; still no resource requirement
+    civ.researched_techs = {f"t{i}" for i in range(Age.BRONZE.min_techs_required)}
+    assert civ.can_advance_age(ts.tech_tree)
+    assert civ.advance_age()
+    assert civ.current_age == Age.BRONZE

--- a/trade_goods.py
+++ b/trade_goods.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+"""Simple trade goods system with support for metal ores and refined goods."""
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict, List, Tuple, Optional
+
+
+class TradeGood(Enum):
+    """Enumeration of available trade goods.
+
+    The list distinguishes between raw ores and their processed counterparts so
+    that technology requirements can track where minerals are mined and how
+    they are refined.  ``*_ORE`` entries represent the raw material while the
+    plain names represent ingots or worked metal.
+    """
+
+    GRAIN = auto()
+    CATTLE = auto()
+    WOOD = auto()
+    WOOL = auto()
+    STONE = auto()
+    COPPER_ORE = auto()
+    TIN_ORE = auto()
+    IRON_ORE = auto()
+    COAL = auto()
+    COPPER = auto()
+    IRON = auto()
+    BRONZE = auto()
+    TOOLS = auto()
+    WEAPONS = auto()
+    CLOTH = auto()
+    POTTERY = auto()
+    FURNITURE = auto()
+    WINE = auto()
+    SILK = auto()
+    JEWELRY = auto()
+    SPICES = auto()
+    INCENSE = auto()
+
+
+# Basic colour mapping used by the visualisation helpers.  The palette only
+# needs to be stable, it does not need to be perfect.
+GOOD_COLOURS: Dict[TradeGood, Tuple[int, int, int]] = {
+    TradeGood.GRAIN: (210, 185, 60),
+    TradeGood.CATTLE: (160, 100, 60),
+    TradeGood.WOOD: (92, 64, 51),
+    TradeGood.WOOL: (200, 200, 200),
+    TradeGood.STONE: (130, 130, 130),
+    TradeGood.COPPER_ORE: (130, 80, 40),
+    TradeGood.TIN_ORE: (180, 180, 180),
+    TradeGood.IRON_ORE: (60, 60, 60),
+    TradeGood.COAL: (30, 30, 30),
+    TradeGood.COPPER: (184, 115, 51),
+    TradeGood.IRON: (80, 80, 80),
+    TradeGood.BRONZE: (140, 120, 70),
+    TradeGood.TOOLS: (120, 120, 150),
+    TradeGood.WEAPONS: (80, 80, 120),
+    TradeGood.CLOTH: (150, 120, 180),
+    TradeGood.POTTERY: (190, 120, 80),
+    TradeGood.FURNITURE: (150, 100, 60),
+    TradeGood.WINE: (150, 0, 0),
+    TradeGood.SILK: (200, 150, 200),
+    TradeGood.JEWELRY: (255, 215, 0),
+    TradeGood.SPICES: (210, 90, 40),
+    TradeGood.INCENSE: (180, 170, 160),
+}
+
+
+@dataclass
+class TradeGoodProduction:
+    """Production data for a single trade good on a tile."""
+
+    percentage: float = 0.0   # Share of workers devoted to this good (0-100)
+    workers: int = 0          # Number of workers
+    efficiency: float = 1.0   # Production efficiency multiplier
+    amount: float = 0.0       # Accumulated production output
+
+
+@dataclass
+class TileTradeGoods:
+    """Trade goods state for a specific tile."""
+
+    ideal_goods: List[TradeGood]
+    max_goods_types: int
+    active_goods: Dict[TradeGood, TradeGoodProduction] = field(default_factory=dict)
+
+
+class TradeGoodsManager:
+    """Manages trade goods production for every tile in the world."""
+
+    def __init__(self, world):
+        self.world = world
+        self.tile_goods: Dict[Tuple[int, int], TileTradeGoods] = {}
+        self._initialize_tiles()
+
+    # ------------------------------------------------------------------
+    # Initialisation helpers
+    # ------------------------------------------------------------------
+    def _initialize_tiles(self) -> None:
+        for tile in self.world.tiles:
+            goods = self._ideal_goods_for_biome(tile.biome)
+            settlement = getattr(tile, "settlement", "hamlet")
+            max_types = self._max_goods_for_settlement(settlement)
+            self.tile_goods[(tile.q, tile.r)] = TileTradeGoods(
+                ideal_goods=goods, max_goods_types=max_types)
+
+    def _ideal_goods_for_biome(self, biome: str) -> List[TradeGood]:
+        mapping = {
+            "grass": [TradeGood.GRAIN, TradeGood.CATTLE, TradeGood.WOOL],
+            "forest": [TradeGood.WOOD, TradeGood.FURS if hasattr(TradeGood, 'FURS') else TradeGood.WOOL],
+            "mountain": [
+                TradeGood.STONE,
+                TradeGood.COPPER_ORE,
+                TradeGood.TIN_ORE,
+                TradeGood.IRON_ORE,
+                TradeGood.COAL,
+            ],
+            "desert": [TradeGood.SPICES, TradeGood.INCENSE],
+            "coast": [TradeGood.FISH if hasattr(TradeGood, 'FISH') else TradeGood.GRAIN],
+            "ocean": [TradeGood.FISH if hasattr(TradeGood, 'FISH') else TradeGood.GRAIN],
+        }
+        return mapping.get(biome, [TradeGood.GRAIN])
+
+    def _max_goods_for_settlement(self, settlement: str) -> int:
+        mapping = {
+            "hamlet": 3,
+            "village": 5,
+            "town": 7,
+            "city": 10,
+            "capital": 10,
+        }
+        return mapping.get(settlement, 3)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save_json(self) -> Dict:
+        data = {}
+        for (q, r), tg in self.tile_goods.items():
+            data[f"{q},{r}"] = {
+                "ideal_goods": [g.name for g in tg.ideal_goods],
+                "max_goods_types": tg.max_goods_types,
+                "active_goods": {
+                    g.name: vars(prod) for g, prod in tg.active_goods.items()
+                },
+            }
+        return data
+
+    def load_json(self, data: Dict) -> None:
+        self.tile_goods.clear()
+        for key, tg_data in data.items():
+            q, r = map(int, key.split(","))
+            tg = TileTradeGoods(
+                ideal_goods=[TradeGood[g] for g in tg_data.get("ideal_goods", [])],
+                max_goods_types=tg_data.get("max_goods_types", 3),
+                active_goods={
+                    TradeGood[g]: TradeGoodProduction(**prod)
+                    for g, prod in tg_data.get("active_goods", {}).items()
+                },
+            )
+            self.tile_goods[(q, r)] = tg
+
+    # ------------------------------------------------------------------
+    # Simulation logic
+    # ------------------------------------------------------------------
+    def evolve_production(self, q: int, r: int, dt: float) -> None:
+        tg = self.tile_goods.get((q, r))
+        if tg is None:
+            return
+        for prod in tg.active_goods.values():
+            prod.amount += prod.percentage / 100.0 * prod.efficiency * dt
+
+    def get_province_trade_summary(self, tiles: List[Tuple[int, int]]) -> Dict[str, float]:
+        summary: Dict[str, float] = {}
+        for coord in tiles:
+            tg = self.tile_goods.get(tuple(coord))
+            if tg is None:
+                continue
+            for good, prod in tg.active_goods.items():
+                summary[good.name] = summary.get(good.name, 0.0) + prod.amount
+        return summary

--- a/trade_goods_example.py
+++ b/trade_goods_example.py
@@ -1,0 +1,412 @@
+"""
+Complete example showing how to use the Trade Goods System
+with your existing civilization simulation
+"""
+
+import pygame
+import json
+from typing import Dict, List, Tuple
+
+# Import your existing modules
+import engine
+from worldgen import biomes
+
+# Import the new trade goods modules
+from trade_goods import TradeGoodsManager, TradeGood
+from trade_goods_viz import TradeGoodsRenderer, TradeGoodsUI
+
+
+class EnhancedGameEngine:
+    """Main game engine with trade goods integration"""
+
+    def __init__(self, width=1200, height=800):
+        pygame.init()
+        self.screen = pygame.display.set_mode((width, height))
+        pygame.display.set_caption("Civilization Simulation - Trade Goods Edition")
+
+        self.clock = pygame.time.Clock()
+        self.running = True
+
+        # Initialize world
+        self.world = None
+        self.trade_manager = None
+        self.trade_ui = None
+
+        # UI state
+        self.selected_tile = None
+        self.show_trade_overlay = True
+        self.show_province_view = False
+
+    def initialize_world(self, world_file=None):
+        """Initialize or load the world with trade goods"""
+
+        if world_file:
+            # Load existing world
+            with open(world_file, 'r') as f:
+                data = json.load(f)
+            self.world = engine.World()
+            self.world.load_json(data)
+
+            # Initialize or load trade goods
+            if 'trade_goods' in data:
+                self.trade_manager = TradeGoodsManager(self.world)
+                self.trade_manager.load_json(data['trade_goods'])
+            else:
+                self.trade_manager = TradeGoodsManager(self.world)
+        else:
+            # Generate new world
+            self.world = engine.World()
+            # ... (your existing world generation code)
+
+            # Initialize trade system
+            self.trade_manager = TradeGoodsManager(self.world)
+
+        # Attach trade manager to world for easy access
+        self.world.trade_manager = self.trade_manager
+
+        # Initialize UI
+        self.trade_ui = TradeGoodsUI(self.screen, self.trade_manager)
+
+    def handle_events(self):
+        """Handle user input events"""
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.running = False
+
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    self.running = False
+
+                # Toggle trade overlay with T
+                elif event.key == pygame.K_t:
+                    self.show_trade_overlay = not self.show_trade_overlay
+
+                # Toggle province view with P
+                elif event.key == pygame.K_p:
+                    self.show_province_view = not self.show_province_view
+
+                # Save game with S
+                elif event.key == pygame.K_s:
+                    self.save_game()
+
+                # Advance turn with SPACE
+                elif event.key == pygame.K_SPACE:
+                    self.advance_turn()
+
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                if event.button == 1:  # Left click
+                    self.handle_tile_click(event.pos)
+                elif event.button == 3:  # Right click
+                    self.selected_tile = None
+
+    def handle_tile_click(self, screen_pos):
+        """Handle clicking on a tile"""
+        # Convert screen position to hex coordinates
+        q, r = self.screen_to_hex(screen_pos)
+
+        # Check if valid tile
+        tile = self.world.get_tile(q, r)
+        if tile:
+            self.selected_tile = (q, r)
+
+            # Update trade UI
+            self.trade_ui.selected_tile = (q, r)
+
+            # Print tile trade info to console
+            self.print_tile_trade_info(q, r)
+
+    def print_tile_trade_info(self, q, r):
+        """Print trade information for a tile to console"""
+        if (q, r) not in self.trade_manager.tile_goods:
+            print(f"No trade goods data for tile ({q}, {r})")
+            return
+
+        tile_goods = self.trade_manager.tile_goods[(q, r)]
+        tile = self.world.get_tile(q, r)
+
+        print(f"\n=== Trade Goods for tile ({q}, {r}) ===")
+        print(f"Settlement: {getattr(tile, 'settlement', 'hamlet')}")
+        print(f"Population: {getattr(tile, 'pop', 0)}")
+        print(f"Max trade good types: {tile_goods.max_goods_types}")
+        print(f"\nActive trade goods:")
+
+        for good, prod in tile_goods.active_goods.items():
+            print(f"  {good.name}:")
+            print(f"    - Percentage: {prod.percentage:.1f}%")
+            print(f"    - Workers: {prod.workers}")
+            print(f"    - Efficiency: {prod.efficiency:.2f}")
+            print(f"    - Production: {prod.amount:.1f}")
+
+    def advance_turn(self):
+        """Advance the game by one turn"""
+        dt = 1.0  # One year per turn
+
+        # Original game advancement
+        engine.advance_turn(self.world, dt)
+
+        # Evolve trade goods
+        for civ_id, civ in self.world.civs.items():
+            for q, r in civ.tiles:
+                self.trade_manager.evolve_production(q, r, dt)
+
+        # Apply economic effects
+        self.apply_trade_economics()
+
+        print("Turn advanced!")
+
+    def apply_trade_economics(self):
+        """Apply economic effects from trade goods"""
+        for civ_id, civ in self.world.civs.items():
+            trade_value = 0
+            unique_goods = set()
+
+            for q, r in civ.tiles:
+                if (q, r) in self.trade_manager.tile_goods:
+                    tile_goods = self.trade_manager.tile_goods[(q, r)]
+
+                    for good, prod in tile_goods.active_goods.items():
+                        unique_goods.add(good)
+
+                        # Calculate value based on good type
+                        base_value = self.get_good_value(good)
+                        trade_value += prod.amount * base_value
+
+            # Apply bonuses
+            diversity_bonus = 1.0 + (len(unique_goods) * 0.02)
+            total_income = trade_value * diversity_bonus
+
+            # Convert to resources
+            if hasattr(civ, 'stock_food'):
+                food_gain = int(total_income * 0.3)
+                civ.stock_food = min(civ.stock_food + food_gain, 999999)
+
+            # Store wealth for future features
+            if not hasattr(civ, 'wealth'):
+                civ.wealth = 0
+            civ.wealth += int(total_income)
+
+    def get_good_value(self, good):
+        """Get the economic value of a trade good"""
+        luxury = [TradeGood.WINE, TradeGood.SILK, TradeGood.JEWELRY,
+                  TradeGood.SPICES, TradeGood.INCENSE]
+        processed = [
+            TradeGood.TOOLS,
+            TradeGood.WEAPONS,
+            TradeGood.CLOTH,
+            TradeGood.POTTERY,
+            TradeGood.FURNITURE,
+            TradeGood.COPPER,
+            TradeGood.IRON,
+            TradeGood.BRONZE,
+        ]
+
+        if good in luxury:
+            return 5.0
+        elif good in processed:
+            return 3.0
+        else:
+            return 1.0
+
+    def render(self):
+        """Render the game"""
+        self.screen.fill((50, 50, 100))  # Ocean blue background
+
+        # Render world tiles
+        self.render_world()
+
+        # Render trade overlays if enabled
+        if self.show_trade_overlay:
+            self.render_trade_overlays()
+
+        # Render selected tile info
+        if self.selected_tile:
+            self.render_tile_info_panel()
+
+        # Render province view if enabled
+        if self.show_province_view:
+            self.render_province_view()
+
+        # Render UI elements
+        self.render_ui()
+
+        pygame.display.flip()
+
+    def render_world(self):
+        """Render the base world map"""
+        # This would be your existing world rendering code
+        # For now, a simple hex grid representation
+
+        for civ_id, civ in self.world.civs.items():
+            for q, r in civ.tiles:
+                tile = self.world.get_tile(q, r)
+                if tile:
+                    x, y = self.hex_to_screen(q, r)
+
+                    # Draw hex (simplified)
+                    color = self.get_tile_color(tile)
+                    pygame.draw.circle(self.screen, color, (x, y), 20)
+
+                    # Draw settlement marker
+                    settlement = getattr(tile, 'settlement', None)
+                    if settlement:
+                        marker_color = (255, 255, 255)
+                        if settlement == 'capital':
+                            pygame.draw.circle(self.screen, marker_color, (x, y), 8)
+                        elif settlement == 'city':
+                            pygame.draw.circle(self.screen, marker_color, (x, y), 6)
+                        elif settlement == 'town':
+                            pygame.draw.circle(self.screen, marker_color, (x, y), 4)
+
+    def render_trade_overlays(self):
+        """Render small pie charts over tiles showing trade goods"""
+        for (q, r), tile_goods in self.trade_manager.tile_goods.items():
+            if len(tile_goods.active_goods) == 0:
+                continue
+
+            x, y = self.hex_to_screen(q, r)
+
+            # Only show for towns and cities
+            tile = self.world.get_tile(q, r)
+            settlement = getattr(tile, 'settlement', '')
+
+            if settlement in ['town', 'city', 'capital']:
+                goods_data = {
+                    good.name: prod.percentage
+                    for good, prod in tile_goods.active_goods.items()
+                }
+
+                # Draw small pie chart
+                renderer = TradeGoodsRenderer(self.screen)
+                renderer.draw_pie_chart((x, y + 30), 15, goods_data,
+                                       show_labels=False)
+
+    def render_tile_info_panel(self):
+        """Render detailed information panel for selected tile"""
+        if not self.selected_tile:
+            return
+
+        q, r = self.selected_tile
+
+        if (q, r) in self.trade_manager.tile_goods:
+            tile_goods = self.trade_manager.tile_goods[(q, r)]
+            tile = self.world.get_tile(q, r)
+            settlement = getattr(tile, 'settlement', 'Settlement')
+
+            # Use the trade UI to render the panel
+            self.trade_ui.renderer.draw_trade_panel((900, 50),
+                                                   tile_goods,
+                                                   f"{settlement} at ({q},{r})")
+
+    def render_province_view(self):
+        """Render province-level trade overview"""
+        # Group tiles by civilization
+        for civ_id, civ in self.world.civs.items():
+            # Get aggregated trade data for this civ
+            province_goods = self.trade_manager.get_province_trade_summary(civ.tiles)
+
+            if province_goods:
+                # Position based on civ ID
+                x = 50 + (civ_id % 3) * 300
+                y = 50 + (civ_id // 3) * 300
+
+                self.trade_ui.renderer.draw_province_overview(
+                    (x, y),
+                    f"Civilization {civ_id}",
+                    province_goods
+                )
+
+    def render_ui(self):
+        """Render UI elements and instructions"""
+        font = pygame.font.Font(None, 24)
+
+        instructions = [
+            "Controls:",
+            "T - Toggle trade overlay",
+            "P - Toggle province view",
+            "SPACE - Advance turn",
+            "S - Save game",
+            "ESC - Exit",
+            "Click tile for details"
+        ]
+
+        y = 10
+        for instruction in instructions:
+            text = font.render(instruction, True, (255, 255, 255))
+            self.screen.blit(text, (10, y))
+            y += 25
+
+    def get_tile_color(self, tile):
+        """Get color for a tile based on biome"""
+        biome = getattr(tile, 'biome', 0)
+
+        # Handle both string and int biomes
+        biome_colors = {
+            'grass': (100, 200, 100),
+            'forest': (50, 150, 50),
+            'mountain': (150, 150, 150),
+            'desert': (240, 220, 130),
+            'ocean': (50, 50, 200),
+            'coast': (100, 100, 200),
+            0: (100, 200, 100),  # grass
+            1: (100, 100, 200),  # coast
+            2: (150, 150, 150),  # mountain
+            3: (50, 50, 200),    # ocean
+            4: (240, 220, 130),  # desert
+        }
+
+        return biome_colors.get(biome, (100, 100, 100))
+
+    def hex_to_screen(self, q, r):
+        """Convert hex coordinates to screen position"""
+        # Simple offset coordinate conversion
+        size = 30
+        x = size * (3/2 * q) + 400
+        y = size * (3**0.5 * (r + q/2)) + 300
+        return int(x), int(y)
+
+    def screen_to_hex(self, screen_pos):
+        """Convert screen position to hex coordinates"""
+        x, y = screen_pos
+        x -= 400
+        y -= 300
+
+        size = 30
+        q = (2/3 * x) / size
+        r = (-1/3 * x + (3**0.5)/3 * y) / size
+
+        # Round to nearest hex
+        return round(q), round(r)
+
+    def save_game(self):
+        """Save the game state including trade goods"""
+        save_data = self.world.save_json()
+        save_data['trade_goods'] = self.trade_manager.save_json()
+
+        with open('savegame_with_trade.json', 'w') as f:
+            json.dump(save_data, f, indent=2)
+
+        print("Game saved!")
+
+    def run(self):
+        """Main game loop"""
+        while self.running:
+            self.handle_events()
+            self.render()
+            self.clock.tick(30)  # 30 FPS
+
+        pygame.quit()
+
+
+# Entry point
+if __name__ == "__main__":
+    game = EnhancedGameEngine()
+
+    # Initialize with existing world or create new
+    try:
+        game.initialize_world('savegame_with_trade.json')
+        print("Loaded existing game")
+    except Exception:
+        game.initialize_world()
+        print("Created new world")
+
+    game.run()

--- a/trade_goods_viz.py
+++ b/trade_goods_viz.py
@@ -1,0 +1,98 @@
+"""Minimal visualisation helpers for the trade goods system.
+
+These classes provide tiny wrappers around ``pygame`` drawing functions so the
+example game can render information about trade goods.  The implementation is
+intentionally lightweight – it only draws simple shapes and text and is not
+optimised for performance.  It is sufficient for demonstration purposes and
+allows the new trade goods system to integrate with the existing codebase.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Tuple
+
+import pygame
+
+from trade_goods import GOOD_COLOURS, TileTradeGoods
+
+
+class TradeGoodsRenderer:
+    """Utility class responsible for drawing trade good information."""
+
+    def __init__(self, screen: pygame.Surface):
+        self.screen = screen
+        self.font = pygame.font.Font(None, 16)
+
+    # ------------------------------------------------------------------
+    def _colour_for(self, name: str) -> Tuple[int, int, int]:
+        for good, col in GOOD_COLOURS.items():
+            if good.name == name:
+                return col
+        # deterministic fallback colour
+        base = abs(hash(name)) & 0xFFFFFF
+        return ((base >> 16) & 255, (base >> 8) & 255, base & 255)
+
+    # ------------------------------------------------------------------
+    def draw_pie_chart(self, centre: Tuple[int, int], radius: int,
+                       data: Dict[str, float], show_labels: bool = True) -> None:
+        """Draw a very small pie chart showing the distribution of ``data``."""
+        total = sum(data.values())
+        if total <= 0:
+            return
+        start = 0.0
+        cx, cy = centre
+        for name, value in data.items():
+            frac = value / total
+            end = start + frac * 2 * math.pi
+            points = [(cx, cy)]
+            steps = max(2, int(frac * 30))
+            for i in range(steps + 1):
+                ang = start + (end - start) * i / steps
+                points.append((cx + radius * math.cos(ang),
+                               cy + radius * math.sin(ang)))
+            pygame.draw.polygon(self.screen, self._colour_for(name), points)
+            start = end
+
+    # ------------------------------------------------------------------
+    def draw_trade_panel(self, pos: Tuple[int, int], tile_goods: TileTradeGoods,
+                         title: str) -> None:
+        """Draw a simple information panel listing tile trade goods."""
+        x, y = pos
+        width, height = 260, 160
+        pygame.draw.rect(self.screen, (0, 0, 0), (x, y, width, height))
+        pygame.draw.rect(self.screen, (200, 200, 200), (x, y, width, height), 2)
+        title_surf = self.font.render(title, True, (255, 255, 255))
+        self.screen.blit(title_surf, (x + 5, y + 5))
+        y_off = 25
+        for good, prod in tile_goods.active_goods.items():
+            text = f"{good.name}: {prod.percentage:.1f}%"
+            surf = self.font.render(text, True, (255, 255, 255))
+            self.screen.blit(surf, (x + 10, y + y_off))
+            y_off += 18
+
+    # ------------------------------------------------------------------
+    def draw_province_overview(self, pos: Tuple[int, int], title: str,
+                               goods: Dict[str, float]) -> None:
+        x, y = pos
+        width, height = 220, 120
+        pygame.draw.rect(self.screen, (0, 0, 0), (x, y, width, height))
+        pygame.draw.rect(self.screen, (200, 200, 200), (x, y, width, height), 2)
+        title_surf = self.font.render(title, True, (255, 255, 255))
+        self.screen.blit(title_surf, (x + 5, y + 5))
+        y_off = 25
+        for name, amount in goods.items():
+            text = f"{name}: {amount:.1f}"
+            surf = self.font.render(text, True, (255, 255, 255))
+            self.screen.blit(surf, (x + 10, y + y_off))
+            y_off += 18
+
+
+class TradeGoodsUI:
+    """Convenience wrapper bundling the renderer with selection state."""
+
+    def __init__(self, screen: pygame.Surface, manager):
+        self.screen = screen
+        self.manager = manager
+        self.renderer = TradeGoodsRenderer(screen)
+        self.selected_tile: Tuple[int, int] | None = None


### PR DESCRIPTION
## Summary
- drop metal ore requirements from age progression and metallurgy techs, leaving only coal for industrialisation
- extend trade goods with coal and link it to mountain tiles
- adjust technology resource tests for ore-free advancement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f312b00832c8245ebd2658c3abb