### PR TITLE
Improve population handling during expansion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1799,12 +1799,13 @@ class GodsimGUI:
                         linguistic_type = self.cultures[culture_id].linguistic_type
             
             eng.world.civs[civ.id] = Civ(
-                civ_id=civ.id, 
+                civ_id=civ.id,
                 name=civ.name,
-                stock_food=100, 
+                stock_food=100,
                 tiles=[],
                 main_culture=main_culture,
-                linguistic_type=linguistic_type
+                linguistic_type=linguistic_type,
+                capital=civ.capital
             )
             # Initialize tech system for this civilization
             if hasattr(eng, 'tech_system') and eng.tech_system:


### PR DESCRIPTION
## Summary
- Add capital tracking to civilizations and expose in world setup
- Rebalance population each turn, moving settlers into sparse tiles and keeping capitals dominant
- Release ownership of tiles whose population falls to zero

## Testing
- `python -m py_compile engine.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f988d34832cba0f646025a874d1