### PR TITLE
Prioritize colonization and sustain minimum population

### DIFF
--- a/sim/settlements.py
+++ b/sim/settlements.py
@@ -559,7 +559,8 @@ def promote_best_hamlet_locations(settlement_map: NDArray[np.uint8],
     
     # Sort by score and return best candidates
     candidates.sort(key=lambda x: x[2], reverse=True)
-    return [(r, c) for r, c, score in candidates[:2]]  # Return up to 2 best locations per civ
+    # Return up to 5 best locations per civ to encourage more settlements
+    return [(r, c) for r, c, score in candidates[:5]]
 
 
 def get_settlement_name(settlement_type: int) -> str:


### PR DESCRIPTION
## Summary
- Prioritize territorial expansion by skipping settlement upgrades when colonization candidates exist and promote villages more aggressively
- Prevent owned tiles from being abandoned by clamping population to at least one
- Consider up to five candidate hamlet locations per civ to spawn more settlements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc83d3a6a0832ca3ba432cbf5f81fe