### PR TITLE
Balance colonization distance decay

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -700,7 +700,8 @@ class SimulationEngine:
             elif capital_distance == 2:
                 score += 5.0   # Good bonus for tiles near capital
             else:
-                score -= capital_distance * 0.5  # Penalty for distant tiles
+                # Apply a gentler distance penalty so far tiles remain viable
+                score -= min(capital_distance * 0.2, 3.0)
         
         # Bonus for adjacency to existing tiles (connectivity)
         adjacent_owned = 0


### PR DESCRIPTION
## Summary
- Soften colonization distance penalty by capping decay to encourage expansion beyond the capital

## Testing
- `python -m pytest test_5000_year_simulation.py::test_5000_year_growth -s`

------
https://chatgpt.com/codex/tasks/task_e_68be08fa6c74832cafd74e6e7a1a9174